### PR TITLE
Fix state change on exception during task state change

### DIFF
--- a/mistral/engine/default_engine.py
+++ b/mistral/engine/default_engine.py
@@ -235,8 +235,16 @@ class DefaultEngine(base.Engine, coordination.Service):
                 # If workflow is on pause or completed then there's no
                 # need to continue workflow.
                 if states.is_paused_or_completed(wf_ex.state):
-                    return action_ex
+                    return action_ex.get_clone()
 
+            # Separate the task transition in a separate transaction. The task
+            # has already completed for better or worst. The task state should
+            # not be affected by errors during transition on conditions such as
+            # on-success and on-error.
+            with db_api.transaction():
+                action_ex = db_api.get_action_execution(action_ex_id)
+                task_ex = action_ex.task_execution
+                wf_ex = action_ex.task_execution.workflow_execution
                 self._on_task_state_change(task_ex, wf_ex)
 
                 return action_ex.get_clone()


### PR DESCRIPTION
If there is an exception during on_task_state_change, particularly if
there is a YAQL evaluation error in the input of the next task, the state
of the current task and related action execution will be marked ERROR for
sync task and rolled back for async task, leaving the task as orphaned in
RUNNING state in most cases. This is a workflow handling error and the
workflow execution state is already marked ERROR. The state of the current
task execution should not be affected.

Change-Id: Id28b0661c09efa80a666d9eb7606fb435641a989
Closes-Bug: #1510738
