### PR TITLE
Fix mistral API raising UnicodeEncodeError

### DIFF
--- a/mistral/utils/__init__.py
+++ b/mistral/utils/__init__.py
@@ -193,8 +193,8 @@ def cut_dict(d, length=100):
     idx = 0
 
     for key, value in d.items():
-        k = str(key)
-        v = str(value)
+        k = unicode(key)
+        v = unicode(value)
 
         # Processing key.
         new_len = len(res) + len(k)


### PR DESCRIPTION
```
vagrant@st2packages-u16:~$ mistral run-action std.echo '{"output":"💩"}'
ERROR (app) RemoteError: Remote error: UnicodeEncodeError 'ascii' codec can't encode characters in position 0-3: ordinal not in range(128)
[u'Traceback (most recent call last):\n', u'  File "/opt/stackstorm/mistral/local/lib/python2.7/site-packages/oslo_messaging/rpc/server.py", line 157, in _process_incoming\n    res = self.dispatcher.dispatch(message)\n', u'  File "/opt/stackstorm/mistral/local/lib/python2.7/site-packages/oslo_messaging/rpc/dispatcher.py", line 213, in dispatch\n    return self._do_dispatch(endpoint, method, ctxt, args)\n', u'  File "/opt/stackstorm/mistral/local/lib/python2.7/site-packages/oslo_messaging/rpc/dispatcher.py", line 183, in _do_dispatch\n    result = func(ctxt, **new_args)\n', u'  File "/opt/stackstorm/mistral/local/lib/python2.7/site-packages/mistral/engine/engine_server.py", line 122, in start_action\n    % (rpc_ctx, action_name, utils.cut(action_input),\n', u'  File "/opt/stackstorm/mistral/local/lib/python2.7/site-packages/mistral/utils/__init__.py", line 283, in cut\n    return cut_dict(data, length=length)\n', u'  File "/opt/stackstorm/mistral/local/lib/python2.7/site-packages/mistral/utils/__init__.py", line 197, in cut_dict\n    v = str(value)\n', u"UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-3: ordinal not in range(128)\n"].
```