### PR TITLE
Use troveclient 2.9.0 which works with our version of mistralclient

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -107,7 +107,7 @@ python-openstackclient==3.11.0
 python-senlinclient==1.3.0
 python-swiftclient==3.3.0
 python-tackerclient==0.9.0
-python-troveclient==2.10.0
+python-troveclient==2.9.0
 python-zaqarclient==1.6.0
 pytz==2017.2
 PyYAML==3.12


### PR DESCRIPTION
During build we update our packages to use `python-mistralclient` from our fork and set version to st2 version - in this case that is `2.3.0`.

New version of `python-troveclient` requires `python-mistralclient>=3.2` which our fork doesn't meet so build fails - https://circleci.com/gh/StackStorm/st2-packages/2424.

In the past it worked out of pure luck, because trove happened to depend on `python-mistralclient>=2.0`.

This is a hack and not a real long-term solution, but sadly I can't think of a better one which would work with the versioning hacking we do.

I can't even "hack" `python-troveclient` requirements.txt to loosen python-mistralclient version specified, because we use dh-virtualenv so we have very little options available and all of them are hacks.

/cc @m4dcoder 