### PR TITLE
Add missing 'xenial' in circle.yml

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -18,7 +18,7 @@ general:
 
 machine:
   environment:
-    DISTROS: "wheezy jessie trusty el6 el7"
+    DISTROS: "wheezy jessie trusty xenial el6 el7"
     NOTESTS: "el7"
     ST2_PACKAGES_REPO: https://github.com/StackStorm/st2-packages
     ST2_PACKAGES_BRANCH: master  # XXX: Set this to vX.Y for release branches


### PR DESCRIPTION
When triggering a build in `mistral` repo, xenial packages are not built, since they're missing in `circle.yml`.