### PR TITLE
Add missing ST2MISTRAL_GITREV to circle.yml

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -21,7 +21,10 @@ machine:
     DISTROS: "wheezy jessie trusty el6 el7"
     NOTESTS: "el7"
     ST2_PACKAGES_REPO: https://github.com/StackStorm/st2-packages
-    ST2_PACKAGES_BRANCH: master  # XXX: Set this to vX.Y for release branches
+    # XXX: Set this to 'vX.Y' for release branches
+    ST2_PACKAGES_BRANCH: master
+    # XXX: Set this to 'st2-X.Y.Z' for the release branches
+    ST2MISTRAL_GITREV: master
     ST2_DOCKERFILES_REPO: https://github.com/StackStorm/st2-dockerfiles
     ST2_PACKAGES: "st2mistral"
     BUILD_DOCKER: 0


### PR DESCRIPTION
`ST2MISTRAL_GITREV` should be set for a replacement later in the release branch.
Same as we do in https://github.com/StackStorm/st2-packages/blob/v2.3/circle.yml#L30