### PR TITLE
Add missing ST2MISTRAL_GITREV to circle.yml (2.3.0)

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -21,7 +21,10 @@ machine:
     DISTROS: "wheezy jessie trusty xenial el6 el7"
     NOTESTS: "el7"
     ST2_PACKAGES_REPO: https://github.com/StackStorm/st2-packages
-    ST2_PACKAGES_BRANCH: v2.3  # XXX: Set this to vX.Y for release branches
+    # XXX: Set this to 'vX.Y' for release branches
+    ST2_PACKAGES_BRANCH: v2.3
+    # XXX: Set this to 'st2-X.Y.Z' for the release branches
+    ST2MISTRAL_GITREV: st2-2.3.0
     ST2_DOCKERFILES_REPO: https://github.com/StackStorm/st2-dockerfiles
     ST2_PACKAGES: "st2mistral"
     BUILD_DOCKER: 0


### PR DESCRIPTION
Related to https://github.com/StackStorm/mistral/pull/28

ST2MISTRAL_GITREV is missing, leading us to build `master` branch and publish it as `stable`.

Pin it, same as we do in https://github.com/StackStorm/st2-packages/blob/v2.3/circle.yml#L30

TODO: Fix/automate with the machinery, same as https://github.com/StackStorm/mistral/pull/25/