### PR TITLE
Remove Debian Wheezy and Jessie

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -18,8 +18,8 @@ general:
 
 machine:
   environment:
-    DISTROS: "wheezy jessie trusty xenial el6 el7"
-    NOTESTS: "el7"
+    DISTROS: "trusty xenial el6 el7"
+    NOTESTS: "xenial el7"
     ST2_PACKAGES_REPO: https://github.com/StackStorm/st2-packages
     # XXX: Set this to 'vX.Y' for release branches
     ST2_PACKAGES_BRANCH: master

--- a/circle.yml
+++ b/circle.yml
@@ -7,11 +7,6 @@
 # DOCKER_EMAIL
 # DOCKER_PASSWORD
 general:
-  # Don't run CI for PR, only for major branches
-  branches:
-    only:
-      - master
-      - /st2-[0-9]+\.[0-9]+\.[0-9]+/
   build_dir: st2-packages
   artifacts:
     - ~/packages

--- a/circle.yml
+++ b/circle.yml
@@ -7,6 +7,11 @@
 # DOCKER_EMAIL
 # DOCKER_PASSWORD
 general:
+  # Don't run CI for PR, only for major branches
+  branches:
+    only:
+      - master
+      - /st2-[0-9]+\.[0-9]+\.[0-9]+/
   build_dir: st2-packages
   artifacts:
     - ~/packages


### PR DESCRIPTION
Work on https://github.com/StackStorm/st2-packages/issues/365 to remove Debian `wheezy` and `jessie` packages.