### PR TITLE
Fix build failure caused by docker-compose incompatibility

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -57,7 +57,7 @@ dependencies:
     - sudo .circle/fix-cache-permissions.sh
     - sudo apt-get -y install parallel jq
     - gem install package_cloud
-    - sudo pip install docker-compose
+    - sudo pip install "docker-compose==1.14.0"
     - docker-compose version
     - docker version
   override:


### PR DESCRIPTION
Pinning docker-compose ver should fix the failed builds.

Old and know issue. See https://github.com/StackStorm/st2-packages/pull/475 for more context.