### PR TITLE
Add maximum version to cachetools dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ alembic>=0.8.10 # MIT
 aodhclient>=0.9.0 # Apache-2.0
 Babel!=2.4.0,>=2.3.4 # BSD
 croniter>=0.3.4 # MIT License
-cachetools>=2.0.0 # MIT License
+cachetools<3.0,>=2.0.0 # MIT License
 eventlet!=0.18.3,!=0.20.1,<0.21.0,>=0.18.2 # MIT
 gnocchiclient>=3.3.1 # Apache-2.0
 Jinja2!=2.9.0,!=2.9.1,!=2.9.2,!=2.9.3,!=2.9.4,>=2.8 # BSD License (3 clause)


### PR DESCRIPTION
[This change](https://github.com/tkem/cachetools/commit/5b85b3f523e92913fd742d35fb409e1caf9cec57#diff-e6234a1939c075bee5dd078e0f7eb672) in [v3.0.0](https://github.com/tkem/cachetools/commit/90d35075eca92d2064bb87ddc1f19f0bf82311c9) of `cacheutils` removes the `missing` argument to the `LRUCache` constructor, which causes [build failures for st2-packages](https://circleci.com/gh/StackStorm/st2-packages/3194#tests/containers/1):

```
TypeError: __init__() got an unexpected keyword argument 'missing'
```

This PR simply limits the maximum version of `cacheutils` to less than v3.0.0.