### PR TITLE
Explicitly pin kombu to 4.2.1 in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
 
+kombu>=4.2.1,<4.2.2 # Apache-2.0
 alembic>=0.8.10 # MIT
 aodhclient>=0.9.0 # Apache-2.0
 Babel!=2.4.0,>=2.3.4 # BSD

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
 
-kombu>=4.2.1,<4.2.2 # Apache-2.0
 alembic>=0.8.10 # MIT
 aodhclient>=0.9.0 # Apache-2.0
 Babel!=2.4.0,>=2.3.4 # BSD
@@ -20,6 +19,10 @@ oslo.config>=5.1.0 # Apache-2.0
 oslo.context>=2.19.2 # Apache-2.0
 oslo.db>=4.27.0 # Apache-2.0
 oslo.i18n>=3.15.3 # Apache-2.0
+# NOTE: oslo.messaging requires kombu 4.2.2 which is broken so we explicitly
+# pin it to a working version here. Keep in mind that this entry needs to be
+# listed before oslo.messaging one
+kombu>=4.2.1,<4.2.2 # Apache-2.0
 oslo.messaging>=5.29.0 # Apache-2.0
 oslo.middleware>=3.31.0 # Apache-2.0
 oslo.policy>=1.30.0 # Apache-2.0


### PR DESCRIPTION
This pull request pins ``kombu`` to ``4.2.1`` which is a working version we also use in StackStorm/st2 repo.

It looks like our "pip freeze" step of the mistral release workflow some how pins kombu to 4.2.2 which is a non working version and brakes things.