### PR TITLE
Deprecate Mistral

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,9 @@
+.. warning::
+    **DEPRECATED!**
+    Mistral workflow engine fork in StackStorm project is deprecated in favor of native StackStorm Orquesta Workflow Engine.
+    Please use Orquesta instead: https://docs.stackstorm.com/orquesta/index.html
+
+
 ========================
 Team and repository tags
 ========================

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,8 @@
+=============
+DEPRECATED!
+=============
+
 .. warning::
-    **DEPRECATED!**
     Mistral workflow engine fork in StackStorm project is deprecated in favor of native StackStorm Orquesta Workflow Engine.
     Please use Orquesta instead: https://docs.stackstorm.com/orquesta/index.html
 


### PR DESCRIPTION
As part of the Mistral Deprecation game plan in st2 `v3.3.0`: StackStorm/st2#4762 add Deprecation warning to the repo readme.